### PR TITLE
Adds integer input support for fuzzyfinder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+
+# pytest
+.cache

--- a/fuzzyfinder/main.py
+++ b/fuzzyfinder/main.py
@@ -16,6 +16,7 @@ def fuzzyfinder(text, collection):
             input.
     """
     suggestions = []
+    text = str(text) if not isinstance(text, str) else text
     pat = '.*?'.join(map(re.escape, text))
     regex = re.compile(pat)
     for item in collection:

--- a/tests/test_fuzzyfinder.py
+++ b/tests/test_fuzzyfinder.py
@@ -19,6 +19,8 @@ def collection():
             'user_group.doc',
             'users.txt',
             'accounts.txt',
+            '123.py',
+            'test123test.py'
             ]
 
 def test_substring_match(collection):
@@ -49,4 +51,10 @@ def test_fuzzy_match_greedy(collection):
     text = 'user'
     results = fuzzyfinder(text, collection)
     expected = ['user_group.doc', 'users.txt', 'api_user.doc']
+    assert list(results) == expected
+
+def test_fuzzy_integer_input(collection):
+    text = 123
+    results = fuzzyfinder(text, collection)
+    expected = ['123.py', 'test123test.py']
     assert list(results) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35
 
 [testenv]
 setenv =


### PR DESCRIPTION
Sometimes people forget to convert `string` to `int`. So now fuzzyfinder can do this for them.
