### PR TITLE
Remove unnecessary `?` in regex

### DIFF
--- a/fuzzyfinder/main.py
+++ b/fuzzyfinder/main.py
@@ -16,7 +16,7 @@ def fuzzyfinder(input, collection, accessor=lambda x: x):
     """
     suggestions = []
     input = str(input) if not isinstance(input, str) else input
-    pat = '.*?'.join(map(re.escape, input))
+    pat = '.*'.join(map(re.escape, input))
     regex = re.compile(pat)
     for item in collection:
         r = regex.search(accessor(item))


### PR DESCRIPTION
`.*` will already match nothing, so it's not necessary to make it optional.

It doesn't seem to make a difference in timing. That's not very surprising, since they are probably compiled into the same internal representation. It saves one byte, though! It's also one less thing to wonder about in the code.
