### PR TITLE
Use shortest match if matches overlap

### DIFF
--- a/fuzzyfinder/main.py
+++ b/fuzzyfinder/main.py
@@ -17,7 +17,7 @@ def fuzzyfinder(input, collection, accessor=lambda x: x):
     suggestions = []
     input = str(input) if not isinstance(input, str) else input
     pat = '.*?'.join(map(re.escape, input))
-    pat = '(?=({}))'.format(pat)   # lookahead regex to manage overlapping matches
+    pat = '(?=({0}))'.format(pat)   # lookahead regex to manage overlapping matches
     regex = re.compile(pat, re.IGNORECASE)
     for item in collection:
         r = list(regex.finditer(accessor(item)))

--- a/fuzzyfinder/main.py
+++ b/fuzzyfinder/main.py
@@ -17,10 +17,12 @@ def fuzzyfinder(input, collection, accessor=lambda x: x):
     suggestions = []
     input = str(input) if not isinstance(input, str) else input
     pat = '.*?'.join(map(re.escape, input))
+    pat = '(?=({}))'.format(pat)   # lookahead regex to manage overlapping matches
     regex = re.compile(pat, re.IGNORECASE)
     for item in collection:
-        r = regex.search(accessor(item))
+        r = list(regex.finditer(accessor(item)))
         if r:
-            suggestions.append((len(r.group()), r.start(), accessor(item), item))
+            best = min(r, key=lambda x: len(x.group(1)))   # find shortest match
+            suggestions.append((len(best.group(1)), best.start(), accessor(item), item))
 
     return (z[-1] for z in sorted(suggestions))

--- a/tests/test_fuzzyfinder.py
+++ b/tests/test_fuzzyfinder.py
@@ -57,6 +57,13 @@ def test_case_insensitive_substring_match(cased_collection):
     expected = ['MIGRATIONS.py', 'migrations.doc', 'django_MiGRations.py']
     assert list(results) == expected
 
+def test_use_shortest_match_if_matches_overlap():
+    collection_list = ['fuuz', 'fuz', 'vfuzzzzz']
+    text = 'fuz'
+    results = fuzzyfinder(text, collection_list)
+    expected = ['fuz', 'vfuzzzzz', 'fuuz']
+    assert list(results) == expected
+
 def test_substring_match_with_dot(collection):
     text = '.txt'
     results = fuzzyfinder(text, collection)

--- a/tests/test_fuzzyfinder.py
+++ b/tests/test_fuzzyfinder.py
@@ -58,10 +58,10 @@ def test_case_insensitive_substring_match(cased_collection):
     assert list(results) == expected
 
 def test_use_shortest_match_if_matches_overlap():
-    collection_list = ['fuuz', 'fuz', 'vfuzzzzz']
+    collection_list = ['fuuz', 'fuz', 'fufuz']
     text = 'fuz'
     results = fuzzyfinder(text, collection_list)
-    expected = ['fuz', 'vfuzzzzz', 'fuuz']
+    expected = ['fuz', 'fufuz', 'fuuz']
     assert list(results) == expected
 
 def test_substring_match_with_dot(collection):


### PR DESCRIPTION
The regex used for finding matches, matches the longest one if they overlap.

```python
import re

regex = re.compile('.*?'.join('fuz'))

regex.search('vfuzzzz')   # 'fuzzzz' is matched instead of 'fuz'
```

So I used look ahead assertions to get the shortest match.