### PR TITLE
ignore_case kwarg added to control case sensitivity

### DIFF
--- a/fuzzyfinder/main.py
+++ b/fuzzyfinder/main.py
@@ -3,7 +3,9 @@ import re
 from . import export
 
 @export
-def fuzzyfinder(input, collection, accessor=lambda x: x, sort_results=True):
+def fuzzyfinder(
+    input, collection, accessor=lambda x: x, sort_results=True, ignore_case=True
+):
     """
     Args:
         input (str): A partial string which is typically entered by a user.
@@ -12,13 +14,15 @@ def fuzzyfinder(input, collection, accessor=lambda x: x, sort_results=True):
         accessor (function): If the `collection` is not an iterable of strings,
                              then use the accessor to fetch the string that
                              will be used for fuzzy matching.
-        sort_results(bool): The suggestions are sorted by considering the
-                            smallest contiguous match, followed by where the
-                            match is found in the full string. If two suggestions
-                            have the same rank, they are then sorted
-                            alpha-numerically. This parameter controls the
-                            *last tie-breaker-alpha-numeric sorting*. The sorting
-                            based on match length and position will be intact.
+        sort_results (bool): The suggestions are sorted by considering the
+                             smallest contiguous match, followed by where the
+                             match is found in the full string. If two suggestions
+                             have the same rank, they are then sorted
+                             alpha-numerically. This parameter controls the
+                             *last tie-breaker-alpha-numeric sorting*. The sorting
+                             based on match length and position will be intact.
+        ignore_case (bool): If this parameter is set to False, the filtering
+                            is case-sensitive.
 
     Returns:
         suggestions (generator): A generator object that produces a list of
@@ -28,7 +32,7 @@ def fuzzyfinder(input, collection, accessor=lambda x: x, sort_results=True):
     input = str(input) if not isinstance(input, str) else input
     pat = '.*?'.join(map(re.escape, input))
     pat = '(?=({0}))'.format(pat)   # lookahead regex to manage overlapping matches
-    regex = re.compile(pat, re.IGNORECASE)
+    regex = re.compile(pat, re.IGNORECASE if ignore_case else 0)
     for item in collection:
         r = list(regex.finditer(accessor(item)))
         if r:

--- a/tests/test_fuzzyfinder.py
+++ b/tests/test_fuzzyfinder.py
@@ -57,6 +57,12 @@ def test_case_insensitive_substring_match(cased_collection):
     expected = ['MIGRATIONS.py', 'migrations.doc', 'django_MiGRations.py']
     assert list(results) == expected
 
+def test_case_sensitive_substring_match(cased_collection):
+    text = 'MiGR'
+    results = fuzzyfinder(text, cased_collection, ignore_case=False)
+    expected = ['django_MiGRations.py']
+    assert list(results) == expected
+
 def test_use_shortest_match_if_matches_overlap():
     collection_list = ['fuuz', 'fuz', 'fufuz']
     text = 'fuz'


### PR DESCRIPTION
Added kwarg `ignore_case` to allow users to opt for case-sensitive filtering.

Resolves #16