### PR TITLE
Bugfix/makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean-pyc clean-build docs clean
+.PHONY: help clean clean-build clean-pyc clean-test test docs
 
 help:
 	@echo "clean - remove all build, test, coverage and Python artifacts"

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ help:
 	@echo "clean - remove all build, test, coverage and Python artifacts"
 	@echo "clean-build - remove build artifacts"
 	@echo "clean-pyc - remove Python file artifacts"
-	@echo "clean-test - remove test and coverage artifacts"
-	@echo "test - run tests on every Python version with tox"
+	@echo "clean-test - remove test, coverage and formatting artifacts"
+	@echo "test - run tests with tox and format with ruff"
 	@echo "docs - generate Sphinx HTML documentation, including API docs"
 
 clean: clean-build clean-pyc clean-test
@@ -29,6 +29,8 @@ clean-test:
 	rm -fr .tox/
 	rm -f .coverage
 	rm -fr htmlcov/
+	rm -fr .pytest_cache/
+	rm -fr .ruff_cache/
 
 test:
 	tox

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ clean-build:
 	rm -fr dist/
 	rm -fr .eggs/
 	find . -name '*.egg-info' -exec rm -fr {} +
-	find . -name '*.egg' -exec rm -f {} +
+	# Directory .tox/, if it exists, contains subdirectories ending with
+	# "egg", so we need to exclude it from the search.
+	find . -name '*.egg' -prune -name ".tox" -exec rm -f {} +
 
 clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +


### PR DESCRIPTION
- `make clean-build`, and by extension `make clean` (in the specific order the subcommands are defined) would fail if there existed a `.tox` directory.
  - Reason: The `.tox` directory contains subdirectories ending with "egg", which `make clean-build` would attempt to delete, without the `-r` flag.

- `make clean-test` now removes the `.ruff_cache` and `.pytest_cache` directories as well.
  - The `.pytest_cache` dir does not get created if testing with tox directly, but since pytest is specfied as a dev dependency I figured some people might run tests simply using pytest.
  - The `ruff_cache` is created when running tox, since the default tox behavior runs linting and formatting as well now. While it might not make too much sense for the `make clean-test` command to remove actual formatting artifacts, one would still want to remove the artifacts, and this is the place it makes the most sense to do it, since `make test` creates the artifacts in the first place.
 
- I also updated the `make help` to reflect the actual behavior.