### PR TITLE
[.gitignore] Add .venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ develop-eggs
 lib
 lib64
 
+# Environments
+.venv
+
 # Installer logs
 pip-log.txt
 


### PR DESCRIPTION
I was using venv and was working on some optimizations. So it would be good to ignore it. I see that `tox` is used. Maybe I should just use `tox`?